### PR TITLE
VIDROBOT-3415 Encode/Decode Shaka-Packager Comment

### DIFF
--- a/mpd/fixtures/comment.mpd
+++ b/mpd/fixtures/comment.mpd
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generated with https://github.com/shaka-project/shaka-packager version 288eddc863-release-->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="1970-01-01T00:00:00Z" minimumUpdatePeriod="PT5S" publishTime="1970-01-01T00:00:00Z"></MPD>

--- a/mpd/fixtures/segment_list.mpd
+++ b/mpd/fixtures/segment_list.mpd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--Generated with https://github.com/shaka-project/shaka-packager version 288eddc863-release-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT30.016S" minBufferTime="PT2.000S">
   <Period>
     <BaseURL>http://localhost:8002/dash/</BaseURL>

--- a/mpd/fixtures/truncate.mpd
+++ b/mpd/fixtures/truncate.mpd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--Generated with https://github.com/shaka-project/shaka-packager version 288eddc863-release-->
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" minBufferTime="PT2S" availabilityStartTime="2019-12-03T20:57:14Z" minimumUpdatePeriod="PT5S" publishTime="2019-12-03T21:05:05Z" timeShiftBufferDepth="PT120S">
   <Period id="0">
     <AdaptationSet frameRate="90000/3000" id="0" segmentAlignment="true" maxWidth="720" contentType="video">

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -88,6 +88,7 @@ type MPD struct {
 	Periods                    []*Period       `xml:"Period,omitempty"`
 	UTCTiming                  *DescriptorType `xml:"UTCTiming,omitempty"`
 	ID                         string          `xml:"id,attr,omitempty"`
+	Comment                    string          `xml:"-"`
 }
 
 type XsiNS struct {

--- a/mpd/mpd_read_write_test.go
+++ b/mpd/mpd_read_write_test.go
@@ -489,3 +489,20 @@ func TestWriteToFileTruncate(t *testing.T) {
 	xmlStr = testfixtures.LoadFixture(out)
 	testfixtures.CompareFixture(t, "fixtures/truncate_short.mpd", xmlStr)
 }
+
+func TestReadComment(t *testing.T) {
+	m, err := ReadFromFile("fixtures/comment.mpd")
+	require.NoError(t, err)
+	require.EqualString(t, "Generated with https://github.com/shaka-project/shaka-packager version 288eddc863-release", string(m.Comment))
+}
+
+func TestWriteComment(t *testing.T) {
+	m := MPD{Comment: "Leading Comment"}
+	s, err := m.WriteToString()
+	require.NoError(t, err)
+	answer := `<?xml version="1.0" encoding="UTF-8"?>
+<!--Leading Comment-->
+<MPD></MPD>
+`
+	require.EqualString(t, answer, s)
+}

--- a/mpd/segment_list_test.go
+++ b/mpd/segment_list_test.go
@@ -22,7 +22,7 @@ func TestSegmentListDeserialization(t *testing.T) {
 	require.NoError(t, err)
 	if err == nil {
 		expected := getSegmentListMPD()
-
+		require.EqualString(t, m.Comment, "Generated with https://github.com/shaka-project/shaka-packager version 288eddc863-release")
 		require.EqualString(t, expected.Periods[0].BaseURL, m.Periods[0].BaseURL)
 
 		expectedAudioSegList := expected.Periods[0].AdaptationSets[0].Representations[0].SegmentList
@@ -59,6 +59,7 @@ func TestSegmentListDeserialization(t *testing.T) {
 
 func getSegmentListMPD() *MPD {
 	m := NewMPD(DASH_PROFILE_LIVE, "PT30.016S", "PT2.000S")
+	m.Comment = "Generated with https://github.com/shaka-project/shaka-packager version 288eddc863-release"
 	m.period.BaseURL = "http://localhost:8002/dash/"
 
 	aas, _ := m.AddNewAdaptationSetAudioWithID("1", "audio/mp4", true, 1, "English")


### PR DESCRIPTION
This PR adds parsing and writing of a comment preceding the XML root element.
[Shaka-packager](https://github.com/shaka-project/shaka-packager) adds a comment before the XML root element, and [whisk](https://github.com/vcd-cbscom/whisk) would like to keep an updated version of this comment.
This adds a simple layer to the MPD encoding/decoding to collect and write the comment.